### PR TITLE
fetch時にキャッシュから取得

### DIFF
--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -70,6 +70,9 @@ self.addEventListener("install", (event) => {
 
 self.addEventListener("fetch", (event) => {
   event.respondWith((async () => {
+    // GET 以外のリクエストでは、ブラウザーに既定のことをさせる
+    if (event.request.method !== "GET") return;
+
     const cachedResponse = await caches.match(event.request);
     if (cachedResponse) {
       console.log("[Service Worker] Return from cash: " + event.request.url);
@@ -79,14 +82,10 @@ self.addEventListener("fetch", (event) => {
     const response = await fetch(event.request).catch((error) => {
       console.error(`[Service Worker] Fetching failed: ${error}`);
     });
-    if (event.request.method != 'GET') {
-      console.log("[Service Worker] Cache is not used for any method other than the GET. the method for this request: " + event.request.method);
-    } else {
-      const cache = await caches.open(CACHE_NAME);
-      await cache.put(event.request, response.clone()).catch(e=>{
-        console.error("[Service Worker] Failed cashing: " + response);
-      });
-    }
+    const cache = await caches.open(CACHE_NAME);
+    await cache.put(event.request, response.clone()).catch(e=>{
+      console.error("[Service Worker] Failed cashing: " + response);
+    });
     return response
   })());
 });

--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -1,5 +1,5 @@
 const NAME = 'firebase-messaging-sw_';
-const VERSION = '009';
+const VERSION = '011';
 const CACHE_NAME = NAME + VERSION;
 const contentToCache = [
   "/",
@@ -61,12 +61,11 @@ messaging.onBackgroundMessage((payload) => {
 self.addEventListener("install", (event) => {
   console.log("Service worker installing...");
   // キャッシュの初期化
-  event.waitUntil(
-    caches.open(CACHE_NAME).then((cache) => {
-      console.log("[Service Worker] Caching all: app shell and content");
-      return cache.addAll(contentToCache);
-    }),
-  );
+  event.waitUntil((async () => {
+    const cache = await caches.open(CACHE_NAME)
+    console.log("[Service Worker] Caching all: app shell and content");
+    return cache.addAll(contentToCache);
+  })());
 });
 
 self.addEventListener("fetch", (event) => {
@@ -94,18 +93,17 @@ self.addEventListener("fetch", (event) => {
 
 self.addEventListener("activate", (event) => {
   console.log("Service worker activating...");
-  event.waitUntil(
-    caches.keys().then((keyList) => {
-      return Promise.all(
-        keyList.map((key) => {
-          if (key !== CACHE_NAME) {
-            console.log("[Service Worker] delete unused cash: " + key);
-            return caches.delete(key);
-          }
-        }),
-      );
-    }),
-  );
+  event.waitUntil((async () => {
+    const keyList = await caches.keys()
+    return Promise.all(
+      keyList.map((key) => {
+        if (key !== CACHE_NAME) {
+          console.log("[Service Worker] delete unused cash: " + key);
+          return caches.delete(key);
+        }
+      }),
+    );
+  })());
 });
 
 // self.addEventListener("push", (event) => {


### PR DESCRIPTION
# fetch時にキャッシュから取得

## やったこと
- サービスワーカーがfetch処理をインタラプトし、２回目以降はキャッシュから返却するようにしました
<img width="1268" alt="image" src="https://github.com/ririringer/drawing-board/assets/37492334/4326dd5c-030a-4cb2-b389-c62437432337">

## やってないこと
- 解せないですが `addEventListener("fetch"` が、POSTリクエスト時にも発火しているように見えます。fetchなのでPOSTリクエストはインタラプトしない認識なんですが、デバックしていると確かに発生していました。原因掴めず、GET以外は無視するようなバリデーションを入れています。
 
## 動作確認

- 開発者ツールのネットワークタブを開いた状態で `http://localhost:5173/` を表示
- 初回(Cmd+Shift+Rでも可)は以下のようにNW経由で画像を取得している
  - ![image](https://github.com/ririringer/drawing-board/assets/37492334/7c9b2e5b-5ecf-4d2e-9207-f393327290cf)
- 2回目以降は以下のようにSW経由で画像を取得している
  - <img width="1268" alt="image" src="https://github.com/ririringer/drawing-board/assets/37492334/da199258-36a3-4488-94a0-fa51ff0b6a6e">

## 参考にしたサイト
- https://developer.mozilla.org/ja/docs/Web/Progressive_web_apps/Tutorials/js13kGames/Offline_Service_workers#%E6%9B%B4%E6%96%B0
- https://qiita.com/TakeshiNickOsanai/items/8d012a128827c9db980d#%E5%AE%9F%E9%9A%9B%E3%81%AE%E3%82%A2%E3%83%97%E3%83%AA